### PR TITLE
Implement automatic device selection and info tool

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from mcp.server.fastmcp import FastMCP
 from appium import webdriver
 from appium.options.android import UiAutomator2Options
 from appium.options.ios import XCUITestOptions
+import subprocess
 
 mcp = FastMCP(
     "자동화",
@@ -9,34 +10,150 @@ mcp = FastMCP(
 )
 
 driver = None
+current_device = None
 
 @mcp.tool()
-async def connect(platform: str, deviceName: str, udid: str, appPackage: str = "", appActivity: str = "", bundleId: str = ""):
-    global driver
-    if platform.lower() == "android":
-        options = UiAutomator2Options().load_capabilities({
-            "platformName": "Android",
-            "automationName": "UiAutomator2",
-            "deviceName": deviceName,
-            "udid": udid,
-            "appPackage": appPackage,
-            "appActivity": appActivity,
-            "newCommandTimeout": 60
-        })
-    elif platform.lower() == "ios":
-        options = XCUITestOptions().load_capabilities({
-            "platformName": "iOS",
-            "automationName": "XCUITest",
-            "deviceName": deviceName,
-            "udid": udid,
-            "bundleId": bundleId,
-            "newCommandTimeout": 60
-        })
+async def connect(platform: str, deviceName: str = "", udid: str = "", appPackage: str = "", appActivity: str = "", bundleId: str = ""):
+    """Connect to a mobile device.
+
+    If no ``udid`` is provided this function tries to automatically detect a
+    connected device for the given ``platform``. When multiple devices are
+    available a list of serial numbers is returned so the caller can invoke
+    this function again with the desired ``udid``.
+    """
+    global driver, current_device
+
+    platform_lower = platform.lower()
+
+    if platform_lower == "android":
+        if not udid:
+            try:
+                result = subprocess.run(["adb", "devices", "-l"], capture_output=True, text=True)
+            except FileNotFoundError:
+                return "adb 명령을 찾을 수 없습니다."
+            devices = []
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                if not line or line.startswith("List of devices"):
+                    continue
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == "device":
+                    serial = parts[0]
+                    model = ""
+                    for p in parts[2:]:
+                        if p.startswith("model:"):
+                            model = p.split(":", 1)[1]
+                            break
+                    devices.append((serial, model))
+            if not devices:
+                return "연결된 Android 장치가 없습니다."
+            if len(devices) > 1:
+                info = "\n".join([f"{d[0]} ({d[1]})" for d in devices])
+                return (
+                    "여러 Android 장치가 연결되어 있습니다:\n"
+                    f"{info}\n"
+                    "connect 명령을 시리얼 번호와 함께 다시 호출해주세요."
+                )
+            udid, deviceName = devices[0]
+
+        os_version = ""
+        try:
+            res = subprocess.run(
+                ["adb", "-s", udid, "shell", "getprop", "ro.build.version.release"],
+                capture_output=True,
+                text=True,
+            )
+            os_version = res.stdout.strip()
+        except Exception:
+            pass
+
+        options = UiAutomator2Options().load_capabilities(
+            {
+                "platformName": "Android",
+                "automationName": "UiAutomator2",
+                "deviceName": deviceName,
+                "udid": udid,
+                "appPackage": appPackage,
+                "appActivity": appActivity,
+                "newCommandTimeout": 60,
+            }
+        )
+
+    elif platform_lower == "ios":
+        if not udid:
+            try:
+                result = subprocess.run(["idevice_id", "-l"], capture_output=True, text=True)
+            except FileNotFoundError:
+                return "idevice_id 명령을 찾을 수 없습니다."
+            ids = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            if not ids:
+                return "연결된 iOS 장치가 없습니다."
+            if len(ids) > 1:
+                info = "\n".join(ids)
+                return (
+                    "여러 iOS 장치가 연결되어 있습니다:\n"
+                    f"{info}\n"
+                    "connect 명령을 시리얼 번호와 함께 다시 호출해주세요."
+                )
+            udid = ids[0]
+
+        if not deviceName:
+            try:
+                name_res = subprocess.run(
+                    ["ideviceinfo", "-u", udid, "-k", "DeviceName"],
+                    capture_output=True,
+                    text=True,
+                )
+                deviceName = name_res.stdout.strip()
+            except Exception:
+                deviceName = ""
+
+        os_version = ""
+        try:
+            os_res = subprocess.run(
+                ["ideviceinfo", "-u", udid, "-k", "ProductVersion"],
+                capture_output=True,
+                text=True,
+            )
+            os_version = os_res.stdout.strip()
+        except Exception:
+            pass
+
+        options = XCUITestOptions().load_capabilities(
+            {
+                "platformName": "iOS",
+                "automationName": "XCUITest",
+                "deviceName": deviceName,
+                "udid": udid,
+                "bundleId": bundleId,
+                "newCommandTimeout": 60,
+            }
+        )
+
     else:
         return "지원하지 않는 플랫폼입니다."
 
     driver = webdriver.Remote("http://localhost:4723", options=options)
+    current_device = {
+        "udid": udid,
+        "deviceName": deviceName,
+        "platform": platform,
+        "osVersion": os_version,
+    }
     return f"{platform} device 연결 완료"
+
+
+@mcp.tool()
+async def current_device_info():
+    """Return information about the currently connected device."""
+    global current_device
+    if not current_device:
+        return "현재 연결된 장치가 없습니다."
+    return (
+        f"시리얼: {current_device['udid']}, "
+        f"이름: {current_device['deviceName']}, "
+        f"OS 버전: {current_device['osVersion']}"
+    )
 
 @mcp.tool()
 async def screenshot():
@@ -83,10 +200,11 @@ async def long_press(by: str, value: str, duration: int = 2000):
 
 @mcp.tool()
 async def disconnect():
-    global driver
+    global driver, current_device
     if driver:
         driver.quit()
         driver = None
+    current_device = None
     return "장치 연결 해제됨"
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle automatic device selection in `connect`
- add `current_device_info` tool to show connected device information
- clear device info on disconnect

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_683a6d18376c8324b8bb70d28d0807e7