### PR TITLE
Add performance options for page source handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,17 @@ python app.py
     "logging": {
         "level": "INFO",
         "enable_detailed_logs": false
+    },
+    "performance": {
+        "use_json_source": true,
+        "ignore_unimportant_views": true
     }
 }
 ```
+
+### 성능 최적화 옵션
+- `use_json_source` : iOS 페이지 소스를 JSON 포맷으로 받아 속도를 높입니다.
+- `ignore_unimportant_views` : Android에서 중요하지 않은 뷰를 제외해 페이지 소스 크기를 줄입니다.
 
 ## 📱 사용 가능한 MCP 도구들
 

--- a/config.json
+++ b/config.json
@@ -18,5 +18,9 @@
     "logging": {
         "level": "INFO",
         "enable_detailed_logs": false
+    },
+    "performance": {
+        "use_json_source": true,
+        "ignore_unimportant_views": true
     }
-} 
+}


### PR DESCRIPTION
## Summary
- add new performance config section with `use_json_source` and `ignore_unimportant_views`
- apply these options in device connection
- make `get_page_source` and `screen_analysis` support simplified or detailed source
- document the new settings in README

## Testing
- `PYENV_VERSION=3.10.17 python3 -m py_compile app.py start_automation.py`

------
https://chatgpt.com/codex/tasks/task_e_683a7ae7b64c832481f485080b0b1ec1