### PR TITLE
Add tool to activate an app

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ python app.py
 - `is_displayed(by, value)` - 요소 표시 여부 확인
 - `get_attribute(by, value, attribute)` - 요소 속성 가져오기
 - `get_page_source()` - 페이지 소스 가져오기
+- `activate_app(app_id)` - 앱 패키지/번들 ID로 앱 실행
 
 ## 💡 사용 예시
 
@@ -136,6 +137,15 @@ screenshot_base64 = await screenshot()
 
 # 3. 상태 확인
 status = await check_connection_status()
+```
+
+### 앱 실행
+```python
+# 기본 설정에 정의된 앱 실행
+await activate_app("")
+
+# 또는 패키지/번들 ID 직접 지정
+await activate_app("com.example.app")
 ```
 
 ### 특정 디바이스 연결

--- a/app.py
+++ b/app.py
@@ -472,6 +472,31 @@ async def get_attribute(by: str, value: str, attribute: str):
     return element.get_attribute(attribute)
 
 @mcp.tool()
+async def activate_app(app_id: str = ""):
+    """지정한 앱을 실행합니다. 앱 ID가 없으면 기본 설정을 사용합니다."""
+    global driver, current_device
+
+    if not driver:
+        return "디바이스가 연결되지 않았습니다."
+
+    if not app_id:
+        platform = (current_device or {}).get("platform", "").lower()
+        if platform == "android":
+            app_id = config.get("android", {}).get("default_app_package", "")
+        else:
+            app_id = config.get("ios", {}).get("default_bundle_id", "")
+
+    if not app_id:
+        return "실행할 앱 ID를 지정해주세요."
+
+    try:
+        driver.activate_app(app_id)
+        return f"✅ 앱 실행 완료: {app_id}"
+    except Exception as e:
+        logger.error(f"앱 실행 실패: {e}")
+        return f"❌ 앱 실행 실패: {str(e)}"
+
+@mcp.tool()
 async def get_page_source(detailed: bool = False):
     """페이지 소스를 가져옵니다. 간단 모드에서는 플랫폼별 설정을 활용합니다."""
     global driver, current_device


### PR DESCRIPTION
## Summary
- add new `activate_app` MCP tool for launching an app
- document `activate_app` in README with example usage

## Testing
- `python3 -m py_compile app.py start_automation.py`

------
https://chatgpt.com/codex/tasks/task_e_683a7f443dc88324a0fc8f139efb0962