### PR TITLE
Add CLI commands directly to app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,10 @@ import json
 import os
 import time
 import logging
-from typing import Optional, Dict, Any
+import asyncio
+import sys
+import click
+from typing import Dict, Any
 
 # 설정 파일 로드
 CONFIG_FILE = "config.json"
@@ -566,8 +569,170 @@ async def disconnect():
     if auto_stop:
         stop_appium_server()
         return f"✅ 장치 연결 해제 및 Appium 서버 중지 완료{device_info}"
-    
+
     return f"✅ 장치 연결 해제됨{device_info}"
 
+
+# ---------------------------- CLI 정의 ----------------------------
+
+def _run_async(coro):
+    return asyncio.run(coro)
+
+
+@click.group()
+def cli():
+    """Appium MCP 명령행 도구"""
+
+
+@cli.command(name="auto-setup")
+def auto_setup_cmd():
+    click.echo(_run_async(auto_setup()))
+
+
+@cli.command(name="list-devices")
+def list_devices_cmd():
+    click.echo(_run_async(list_available_devices()))
+
+
+@cli.command(name="status")
+def status_cmd():
+    click.echo(_run_async(check_connection_status()))
+
+
+@cli.command(name="restart")
+def restart_cmd():
+    click.echo(_run_async(restart_connection()))
+
+
+@cli.command(name="connect")
+@click.argument("platform")
+@click.option("--udid", default="", help="Device UDID/serial number")
+@click.option("--device-name", default="", help="Device name")
+@click.option("--app-package", default="", help="Android app package")
+@click.option("--app-activity", default="", help="Android app activity")
+@click.option("--bundle-id", default="", help="iOS bundle identifier")
+def connect_cmd(platform, udid, device_name, app_package, app_activity, bundle_id):
+    click.echo(
+        _run_async(
+            connect(
+                platform=platform,
+                deviceName=device_name,
+                udid=udid,
+                appPackage=app_package,
+                appActivity=app_activity,
+                bundleId=bundle_id,
+            )
+        )
+    )
+
+
+@cli.command(name="disconnect")
+def disconnect_cmd():
+    click.echo(_run_async(disconnect()))
+
+
+@cli.command(name="current-device")
+def current_device_cmd():
+    click.echo(_run_async(current_device_info()))
+
+
+@cli.command(name="screenshot")
+def screenshot_cmd():
+    click.echo(_run_async(screenshot()))
+
+
+@cli.command(name="screen-analysis")
+@click.option("--detailed", is_flag=True, help="Use detailed mode for page source")
+def screen_analysis_cmd(detailed):
+    click.echo(_run_async(screen_analysis(detailed=detailed)))
+
+
+@cli.command(name="click-coord")
+@click.argument("x", type=int)
+@click.argument("y", type=int)
+def click_coord_cmd(x, y):
+    click.echo(_run_async(click_coordinates(x, y)))
+
+
+@cli.command(name="click")
+@click.argument("by")
+@click.argument("value")
+def click_element_cmd(by, value):
+    click.echo(_run_async(click(by, value)))
+
+
+@cli.command(name="swipe")
+@click.argument("start_x", type=int)
+@click.argument("start_y", type=int)
+@click.argument("end_x", type=int)
+@click.argument("end_y", type=int)
+@click.option("--duration", default=800, type=int, help="Swipe duration in ms")
+def swipe_cmd(start_x, start_y, end_x, end_y, duration):
+    click.echo(_run_async(swipe(start_x, start_y, end_x, end_y, duration)))
+
+
+@cli.command(name="is-displayed")
+@click.argument("by")
+@click.argument("value")
+def is_displayed_cmd(by, value):
+    click.echo(_run_async(is_displayed(by, value)))
+
+
+@cli.command(name="get-attribute")
+@click.argument("by")
+@click.argument("value")
+@click.argument("attribute")
+def get_attribute_cmd(by, value, attribute):
+    click.echo(_run_async(get_attribute(by, value, attribute)))
+
+
+@cli.command(name="activate-app")
+@click.argument("app_id", default="")
+def activate_app_cmd(app_id):
+    click.echo(_run_async(activate_app(app_id)))
+
+
+@cli.command(name="page-source")
+@click.option("--detailed", is_flag=True, help="Use detailed mode for page source")
+def page_source_cmd(detailed):
+    click.echo(_run_async(get_page_source(detailed=detailed)))
+
+
+@cli.command(name="long-press")
+@click.argument("by")
+@click.argument("value")
+@click.option("--duration", default=2000, type=int, help="Press duration in ms")
+def long_press_cmd(by, value, duration):
+    click.echo(_run_async(long_press(by, value, duration)))
+
+
+@cli.command(name="start-automation")
+def start_automation_cmd():
+    """원클릭 자동화 시작"""
+    try:
+        click.echo("🚀 Appium MCP 자동화를 시작합니다...")
+        click.echo("=" * 50)
+
+        click.echo("📱 사용 가능한 디바이스를 검색합니다...")
+        click.echo(_run_async(list_available_devices()))
+        click.echo()
+
+        click.echo("🔧 자동 설정을 시작합니다...")
+        click.echo(f"결과: {_run_async(auto_setup())}")
+        click.echo()
+
+        click.echo("✅ 연결 상태를 확인합니다...")
+        click.echo(_run_async(check_connection_status()))
+        click.echo()
+
+        click.echo("🎉 자동화 설정이 완료되었습니다!")
+        click.echo("이제 MCP 클라이언트에서 도구들을 사용할 수 있습니다.")
+    except Exception as e:
+        click.echo(f"❌ 오류가 발생했습니다: {e}")
+        sys.exit(1)
+
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    if len(sys.argv) > 1:
+        cli()
+    else:
+        mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary
- keep a single entry point by embedding CLI features in `app.py`
- add async CLI helpers and expose all commands
- choose between running the MCP server or the CLI based on arguments

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683a82292a448324a51a18a46d900f26