### PR TITLE
Fix tool names

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import os
 import time
 import logging
 import requests
+import functools
 from typing import Dict, Any
 
 # 설정 파일 로드
@@ -43,6 +44,7 @@ def _maybe_json(result):
     return result
 
 def json_result(func):
+    @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         res = await func(*args, **kwargs)
         return _maybe_json(res)


### PR DESCRIPTION
## Summary
- preserve function metadata when wrapping tools

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683a98a30ddc8324849c242ce0d61d86