### PR TITLE
Improve JSON output sanitization

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,9 +38,22 @@ appium_process = None
 
 JSON_OUTPUT = os.environ.get("MCP_JSON", "0").lower() in ("1", "true")
 
+def _sanitize(obj):
+    """Remove non-ASCII characters from strings for clean JSON output."""
+    if isinstance(obj, str):
+        return obj.encode("ascii", errors="ignore").decode()
+    if isinstance(obj, list):
+        return [_sanitize(i) for i in obj]
+    if isinstance(obj, dict):
+        return {k: _sanitize(v) for k, v in obj.items()}
+    return obj
+
 def _maybe_json(result):
-    if JSON_OUTPUT and not isinstance(result, (dict, list)):
-        return {"result": result}
+    if JSON_OUTPUT:
+        sanitized = _sanitize(result)
+        if not isinstance(sanitized, (dict, list)):
+            return {"result": sanitized}
+        return sanitized
     return result
 
 def json_result(func):

--- a/cli.py
+++ b/cli.py
@@ -25,9 +25,20 @@ from app import (
 
 JSON_ENV = os.environ.get("MCP_JSON", "0").lower() in ("1", "true")
 
+def _sanitize(obj):
+    """Remove non-ASCII characters from strings for clean JSON output."""
+    if isinstance(obj, str):
+        return obj.encode("ascii", errors="ignore").decode()
+    if isinstance(obj, list):
+        return [_sanitize(i) for i in obj]
+    if isinstance(obj, dict):
+        return {k: _sanitize(v) for k, v in obj.items()}
+    return obj
+
 
 def output_result(result, json_output: bool):
     if json_output:
+        result = _sanitize(result)
         if not isinstance(result, (dict, list)):
             result = {"result": result}
         click.echo(json.dumps(result, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- sanitize JSON output to strip non-ASCII characters
- apply sanitization for CLI output

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683aa03817ec8324af41b05c5c729594