### PR TITLE
Port tests to Python and optimize utilities

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -1,5 +1,6 @@
 import subprocess
 from typing import Literal, Optional, Dict
+from functools import lru_cache
 
 
 DEFAULT_JPEG_QUALITY = 75
@@ -69,6 +70,7 @@ class Image:
         return ImageTransformer(self.buffer).jpeg(options)
 
 
+@lru_cache(maxsize=1)
 def is_imagemagick_installed() -> bool:
     """ImageMagick이 설치되어 있는지 확인합니다."""
     try:

--- a/src/server.py
+++ b/src/server.py
@@ -1,5 +1,6 @@
 import json
 import base64
+import asyncio
 from typing import Optional, Dict, Any, List, Callable
 import aiohttp
 from mcp.server import Server
@@ -14,13 +15,12 @@ from iphone_simulator import SimctlManager
 from ios import IosManager, IosRobot
 from png import PNG
 from image_utils import is_imagemagick_installed, Image
+from __init__ import __version__
 
 
 def get_agent_version() -> str:
     """에이전트 버전을 가져옵니다."""
-    with open("../package.json", "r") as f:
-        data = json.load(f)
-        return data["version"]
+    return __version__
 
 
 async def get_latest_agent_version() -> str:
@@ -275,8 +275,9 @@ def create_mcp_server() -> Server:
                 android_manager = AndroidDeviceManager()
                 devices = simulator_manager.list_booted_simulators()
                 simulator_names = [d.name for d in devices]
+                ios_devices_task = asyncio.create_task(ios_manager.list_devices())
                 android_devices = android_manager.get_connected_devices()
-                ios_devices = await ios_manager.list_devices()
+                ios_devices = await ios_devices_task
                 ios_device_names = [d.device_id for d in ios_devices]
                 android_tv_devices = [d.device_id for d in android_devices if d.device_type == "tv"]
                 android_mobile_devices = [d.device_id for d in android_devices if d.device_type == "mobile"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -1,0 +1,45 @@
+import asyncio
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from android import AndroidRobot, AndroidDeviceManager
+from png import PNG
+
+class TestAndroid(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        manager = AndroidDeviceManager()
+        cls.devices = manager.get_connected_devices()
+        cls.has_device = len(cls.devices) == 1
+        cls.android = AndroidRobot(cls.devices[0].device_id) if cls.has_device else None
+
+    def setUp(self):
+        if not self.has_device:
+            self.skipTest("Requires exactly one Android device")
+
+    def test_get_screen_size(self):
+        screen_size = asyncio.run(self.android.get_screen_size())
+        self.assertGreater(screen_size.width, 1024)
+        self.assertGreater(screen_size.height, 1024)
+        self.assertEqual(screen_size.scale, 1)
+        self.assertEqual(len(screen_size.__dict__), 3)
+
+    def test_take_screenshot(self):
+        screen_size = asyncio.run(self.android.get_screen_size())
+        screenshot = asyncio.run(self.android.get_screenshot())
+        self.assertGreater(len(screenshot), 64 * 1024)
+        image = PNG(screenshot)
+        png_size = image.get_dimensions()
+        self.assertEqual(png_size.width, screen_size.width)
+        self.assertEqual(png_size.height, screen_size.height)
+
+    def test_list_apps(self):
+        apps = asyncio.run(self.android.list_apps())
+        packages = [app.package_name for app in apps]
+        self.assertIn("com.android.settings", packages)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ios.py
+++ b/tests/test_ios.py
@@ -1,0 +1,33 @@
+import asyncio
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+try:
+    from ios import IosManager, IosRobot
+except Exception:  # pragma: no cover - skip if dependencies missing
+    IosManager = None  # type: ignore
+    IosRobot = None  # type: ignore
+
+class TestIOS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if IosManager is None:
+            raise unittest.SkipTest("iOS dependencies missing")
+        cls.manager = IosManager()
+        cls.devices = asyncio.run(cls.manager.list_devices())
+        cls.has_device = len(cls.devices) == 1
+        cls.robot = IosRobot(cls.devices[0].device_id) if cls.has_device else None
+
+    def setUp(self):
+        if not self.has_device:
+            self.skipTest("Requires exactly one iOS device")
+
+    def test_get_screenshot(self):
+        screenshot = asyncio.run(self.robot.get_screenshot())
+        self.assertGreater(len(screenshot), 64 * 1024)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iphone_simulator.py
+++ b/tests/test_iphone_simulator.py
@@ -1,0 +1,67 @@
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+try:
+    from iphone_simulator import Simctl
+except Exception:  # pragma: no cover - skip if dependency missing
+    Simctl = None  # type: ignore
+
+class TestSimctlParsing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if Simctl is None:
+            raise unittest.SkipTest("Simctl dependency missing")
+    def test_parse_listapps_output(self):
+        text = """
+                {
+                        ".xctrunner" =     {
+                                ApplicationType = User;
+                                Bundle = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Bundle/Application/8EB6C622-A298-4BB6-8E29-AA2A5CE062EF/WebDriverAgentRunner-Runner.app/";
+                                BundleContainer = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Bundle/Application/8EB6C622-A298-4BB6-8E29-AA2A5CE062EF/";
+                                CFBundleDisplayName = "WebDriverAgentRunner-Runner";
+                                CFBundleExecutable = "WebDriverAgentRunner-Runner";
+                                CFBundleIdentifier = ".xctrunner";
+                                CFBundleName = "WebDriverAgentRunner-Runner";
+                                CFBundleVersion = 1;
+                                DataContainer = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Data/Application/AE7D36A1-AACA-4171-A070-645992DEAEB9/";
+                                GroupContainers =         {
+                                };
+                                Path = "/Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Bundle/Application/8EB6C622-A298-4BB6-8E29-AA2A5CE062EF/WebDriverAgentRunner-Runner.app";
+                                SBAppTags =         (
+                                );
+                        };
+                        "com.mobilenext.sample1" =     {
+                                ApplicationType = System;
+                                Bundle = "file:///Library/Developer/CoreSimulator/Volumes/iOS_22D8075/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.3.simruntime/Contents/Resources/RuntimeRoot/Applications/Bridge.app/";
+                                CFBundleDisplayName = Sample1;
+                                CFBundleExecutable = Sample1;
+                                CFBundleIdentifier = "com.mobilenext.sample1";
+                                CFBundleName = "Sample{1}App";
+                                CFBundleVersion = "1.0";
+                                DataContainer = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Data/Application/0D5C84C1-044C-4C03-B443-A1416DC1A296/";
+                                GroupContainers =         {
+                                        "243LU875E5.groups.com.apple.podcasts" = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Shared/AppGroup/8B2DA97D-2308-4B65-B87F-1E71493477E5/";
+                                        "group.com.apple.bridge" = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Shared/AppGroup/F6E42206-B548-4F83-AB13-6E5BD7D69AB0/";
+                                        "group.com.apple.iBooks" = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Shared/AppGroup/EEBEC72A-6673-446A-AB31-E154AB850B69/";
+                                        "group.com.apple.mail" = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Shared/AppGroup/C3339457-EB6A-46D1-92A3-AE398DA8CAC5/";
+                                        "group.com.apple.stocks" = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Shared/AppGroup/50E3741D-E249-421F-83E8-24A896A1245B/";
+                                        "group.com.apple.weather" = "file:///Library/Developer/CoreSimulator/Devices/FB9D9985-8FD0-493D-9B09-58FD3AA4BE65/data/Containers/Shared/AppGroup/28D40933-57F1-4B65-864F-1F6538B3ADF9/";
+                                };
+                                Path = "/Library/Developer/CoreSimulator/Volumes/iOS_22D8075/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.3.simruntime/Contents/Resources/RuntimeRoot/Applications/Bridge.app";
+                                SBAppTags =         (
+                                        "watch-companion"
+                                );
+                        };
+                }
+                """
+        apps = Simctl.parse_ios_app_data(text)
+        self.assertEqual(len(apps), 2)
+        self.assertEqual(apps[0].cf_bundle_display_name, "WebDriverAgentRunner-Runner")
+        self.assertEqual(apps[1].cf_bundle_display_name, "Sample1")
+        self.assertEqual(apps[1].cf_bundle_name, "Sample{1}App")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -1,0 +1,25 @@
+import base64
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from png import PNG
+
+class TestPNG(unittest.TestCase):
+    def test_parse_png(self):
+        buffer = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAD0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+        )
+        png = PNG(base64.b64decode(buffer))
+        dims = png.get_dimensions()
+        self.assertEqual(dims.width, 1)
+        self.assertEqual(dims.height, 1)
+
+    def test_invalid_png(self):
+        with self.assertRaises(ValueError):
+            PNG(b"IAMADUCK").get_dimensions()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert TS tests to Python equivalents
- adjust import paths for tests
- use package version in server
- cache ImageMagick check
- optimize device listing with async task

## Testing
- `python3 -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_683aa99734348324ba7dcfef839bc407