### PR TITLE
Add run alias for backward compatibility

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,11 @@ def main() -> None:
     asyncio.run(async_main())
 
 
+def run() -> None:
+    """Backward compatibility entrypoint"""
+    main()
+
+
 if __name__ == "__main__":
     try:
         main()


### PR DESCRIPTION
## Summary
- add `run()` wrapper in main module for older entry scripts

## Testing
- `/usr/bin/python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_683ab145135c8324a1d1f45b5c300182