### PR TITLE
Fix Unicode input with UnicodeIME

### DIFF
--- a/README_python.md
+++ b/README_python.md
@@ -83,6 +83,22 @@ mypy src/
 - **Android:** `설정` → `시스템` → `언어 및 입력` → `가상 키보드` → `Gboard` → `언어` → `키보드 추가` 에서 **한국어**를 선택합니다.
 - **iOS:** `설정` → `일반` → `키보드` → `키보드` → `새로운 키보드 추가`에서 **한국어**를 선택합니다.
 
+### Appium UnicodeIME 활용 방법
+
+`adb shell input text` 명령은 기본적으로 ASCII 문자 입력만 지원합니다.
+한글처럼 비 ASCII 문자를 입력하려면 Appium Settings 앱에 포함된
+**UnicodeIME** 입력기를 사용해야 합니다. `mobile-mcp`는 비 ASCII 문자가
+포함된 문자열을 입력할 때 자동으로 UnicodeIME를 활성화하고
+브로드캐스트 방식으로 텍스트를 전송합니다.
+
+만약 기기에 `io.appium.settings` 앱이 설치되어 있지 않다면 APK를 설치한
+후 다음 명령으로 IME를 활성화할 수 있습니다.
+
+```bash
+adb shell ime enable io.appium.settings/.UnicodeIME
+adb shell ime set io.appium.settings/.UnicodeIME
+```
+
 ## 라이선스
 
 MIT License 

--- a/src/android.py
+++ b/src/android.py
@@ -229,17 +229,39 @@ class AndroidRobot(Robot):
     
     async def send_keys(self, text: str) -> None:
         """키 입력을 전송합니다."""
-        escaped_chars = []
-        for char in text:
-            if char == ' ':
-                escaped_chars.append('\\ ')
-            elif char.isascii():
-                escaped_chars.append(char)
-            else:
-                escaped_chars.append(f"\\u{ord(char):04x}")
+        # 기본적으로는 ``adb shell input text`` 명령을 사용한다. 이 방식은
+        # ASCII 문자에만 제대로 동작하므로 비 ASCII 문자가 포함된 경우에는
+        # Appium UnicodeIME를 통해 브로드캐스트 방식으로 입력을 전달한다.
 
-        escaped_text = ''.join(escaped_chars)
-        self.adb("shell", "input", "text", escaped_text)
+        def is_ascii(s: str) -> bool:
+            try:
+                s.encode("ascii")
+                return True
+            except UnicodeEncodeError:
+                return False
+
+        if is_ascii(text):
+            escaped_text = text.replace(" ", "\\ ")
+            self.adb("shell", "input", "text", escaped_text)
+            return
+
+        # UnicodeIME를 사용하여 유니코드 문자열을 입력한다. 이미 설정되어 있
+        # 거나 설치되지 않은 경우 예외는 무시한다.
+        try:
+            self.adb("shell", "ime", "set", "io.appium.settings/.UnicodeIME")
+        except Exception:
+            pass
+
+        self.adb(
+            "shell",
+            "am",
+            "broadcast",
+            "-a",
+            "ADB_INPUT_TEXT",
+            "--es",
+            "msg",
+            text,
+        )
     
     async def press_button(self, button: Button) -> None:
         """버튼을 누릅니다."""


### PR DESCRIPTION
## Summary
- improve send_keys in AndroidRobot to use UnicodeIME for non-ASCII text
- add docs about activating Appium UnicodeIME

## Testing
- `python -m pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_683ab8df27dc8324806625a5d1cffe2d