### PR TITLE
Fix indentation error in server.py

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -317,7 +317,7 @@ def create_mcp_server() -> Server:
                 screen_size = await robot.get_screen_size()
                 result = f"화면 크기: {screen_size.width}x{screen_size.height} 픽셀"
 
-           elif name == "mobile_click_on_screen_at_coordinates":
+            elif name == "mobile_click_on_screen_at_coordinates":
                 require_robot()
                 x = arguments["x"]
                 y = arguments["y"]


### PR DESCRIPTION
## Summary
- correct indentation for the `mobile_click_on_screen_at_coordinates` command

## Testing
- `python3 -m py_compile src/server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6848ff03faf083249ba56af4aeeb8645