### PR TITLE
Implement coordinate swipe functionality

### DIFF
--- a/src/android.py
+++ b/src/android.py
@@ -189,6 +189,19 @@ class AndroidRobot(Robot):
 
         self.adb("shell", "input", "swipe", str(x0), str(y0), str(x1), str(y1), "1000")
 
+    async def swipe_between_points(self, start_x: int, start_y: int, end_x: int, end_y: int) -> None:
+        """지정된 좌표에서 다른 좌표까지 스와이프합니다."""
+        self.adb(
+            "shell",
+            "input",
+            "swipe",
+            str(start_x),
+            str(start_y),
+            str(end_x),
+            str(end_y),
+            "1000",
+        )
+
     async def get_screenshot(self) -> bytes:
         """스크린샷을 가져옵니다."""
         return self.adb("exec-out", "screencap", "-p")

--- a/src/ios.py
+++ b/src/ios.py
@@ -145,6 +145,13 @@ class IosRobot(Robot):
         """스와이프합니다."""
         wda = await self._wda()
         await wda.swipe(direction)
+
+    async def swipe_between_points(
+        self, start_x: int, start_y: int, end_x: int, end_y: int
+    ) -> None:
+        """지정된 좌표에서 다른 좌표까지 스와이프합니다."""
+        wda = await self._wda()
+        await wda.swipe_between_points(start_x, start_y, end_x, end_y)
     
     async def list_apps(self) -> List[InstalledApp]:
         """설치된 앱 목록을 가져옵니다."""

--- a/src/robot.py
+++ b/src/robot.py
@@ -65,6 +65,12 @@ class Robot(Protocol):
     async def swipe(self, direction: SwipeDirection) -> None:
         """지정된 방향으로 스와이프합니다."""
         ...
+
+    async def swipe_between_points(
+        self, start_x: int, start_y: int, end_x: int, end_y: int
+    ) -> None:
+        """지정된 좌표에서 다른 좌표까지 스와이프합니다."""
+        ...
     
     async def get_screenshot(self) -> bytes:
         """화면의 스크린샷을 가져옵니다. PNG 이미지가 포함된 bytes를 반환합니다."""

--- a/src/server.py
+++ b/src/server.py
@@ -186,9 +186,16 @@ def create_mcp_server() -> Server:
                             "type": "string",
                             "enum": ["up", "down", "left", "right"],
                             "description": "스와이프 방향",
-                        }
+                        },
+                        "start_x": {"type": "integer", "description": "시작 X 좌표"},
+                        "start_y": {"type": "integer", "description": "시작 Y 좌표"},
+                        "end_x": {"type": "integer", "description": "끝 X 좌표"},
+                        "end_y": {"type": "integer", "description": "끝 Y 좌표"},
                     },
-                    "required": ["direction"],
+                    "anyOf": [
+                        {"required": ["direction"]},
+                        {"required": ["start_x", "start_y", "end_x", "end_y"]},
+                    ],
                 },
             ),
             Tool(
@@ -368,9 +375,19 @@ def create_mcp_server() -> Server:
 
             elif name == "swipe_on_screen":
                 require_robot()
-                direction = arguments["direction"]
-                await robot.swipe(direction)
-                result = f"화면에서 {direction} 방향으로 스와이프됨"
+                if "direction" in arguments:
+                    direction = arguments["direction"]
+                    await robot.swipe(direction)
+                    result = f"화면에서 {direction} 방향으로 스와이프됨"
+                else:
+                    start_x = arguments["start_x"]
+                    start_y = arguments["start_y"]
+                    end_x = arguments["end_x"]
+                    end_y = arguments["end_y"]
+                    await robot.swipe_between_points(start_x, start_y, end_x, end_y)
+                    result = (
+                        f"화면에서 ({start_x},{start_y}) -> ({end_x},{end_y}) 로 스와이프됨"
+                    )
 
             elif name == "mobile_type_keys":
                 require_robot()

--- a/src/webdriver_agent.py
+++ b/src/webdriver_agent.py
@@ -315,6 +315,45 @@ class WebDriverAgent:
 
         await self.within_session(_swipe)
 
+    async def swipe_between_points(
+        self, start_x: int, start_y: int, end_x: int, end_y: int
+    ) -> None:
+        """지정된 좌표에서 다른 좌표까지 스와이프합니다."""
+
+        async def _swipe(session_url: str) -> None:
+            url = f"{session_url}/actions"
+            actions = {
+                "actions": [
+                    {
+                        "type": "pointer",
+                        "id": "finger1",
+                        "parameters": {"pointerType": "touch"},
+                        "actions": [
+                            {
+                                "type": "pointerMove",
+                                "duration": 0,
+                                "x": start_x,
+                                "y": start_y,
+                            },
+                            {"type": "pointerDown", "button": 0},
+                            {
+                                "type": "pointerMove",
+                                "duration": 0,
+                                "x": end_x,
+                                "y": end_y,
+                            },
+                            {"type": "pause", "duration": 1000},
+                            {"type": "pointerUp", "button": 0},
+                        ],
+                    }
+                ]
+            }
+
+            async with aiohttp.ClientSession() as session:
+                await session.post(url, json=actions)
+
+        await self.within_session(_swipe)
+
     async def set_orientation(self, orientation: Orientation) -> None:
         """화면 방향을 설정합니다."""
 

--- a/tests/test_swipe.py
+++ b/tests/test_swipe.py
@@ -41,6 +41,16 @@ class TestSwipeGestures(unittest.TestCase):
             self.assertEqual(args[2], "swipe")
             self.assertEqual(args[3:], ("800", "1000", "200", "1000", "1000"))
 
+    def test_android_swipe_between_points(self):
+        robot = AndroidRobot("serial")
+        with patch.object(robot, "adb") as mock_adb:
+            asyncio.run(robot.swipe_between_points(10, 20, 30, 40))
+            args = mock_adb.call_args[0]
+            self.assertEqual(args[0], "shell")
+            self.assertEqual(args[1], "input")
+            self.assertEqual(args[2], "swipe")
+            self.assertEqual(args[3:], ("10", "20", "30", "40", "1000"))
+
     def test_wda_swipe_right(self):
         wda = WebDriverAgent("localhost", 8100)
         posts = []
@@ -60,6 +70,22 @@ class TestSwipeGestures(unittest.TestCase):
             self.assertEqual(actions[0]["y"], 500)
             self.assertEqual(actions[2]["x"], 800)
             self.assertEqual(actions[2]["y"], 500)
+
+    def test_wda_swipe_between_points(self):
+        wda = WebDriverAgent("localhost", 8100)
+        posts = []
+        with patch.object(
+            wda, "within_session", side_effect=lambda fn: fn("http://localhost:8100/session/1")
+        ), patch(
+            "aiohttp.ClientSession", lambda: DummySession(posts)
+        ):
+            asyncio.run(wda.swipe_between_points(1, 2, 3, 4))
+            self.assertEqual(posts[0][0], "http://localhost:8100/session/1/actions")
+            actions = posts[0][1]["actions"][0]["actions"]
+            self.assertEqual(actions[0]["x"], 1)
+            self.assertEqual(actions[0]["y"], 2)
+            self.assertEqual(actions[2]["x"], 3)
+            self.assertEqual(actions[2]["y"], 4)
 
 
 if __name__ == "__main__":

--- a/typescript_backup/src/android.ts
+++ b/typescript_backup/src/android.ts
@@ -117,7 +117,7 @@ export class AndroidRobot implements Robot {
 			.map(line => line.split(/\s+/)[8]); // get process name
 	}
 
-	public async swipe(direction: SwipeDirection): Promise<void> {
+        public async swipe(direction: SwipeDirection): Promise<void> {
 		const screenSize = await this.getScreenSize();
                 const centerX = screenSize.width >> 1;
                 const centerY = screenSize.height >> 1;
@@ -149,8 +149,21 @@ export class AndroidRobot implements Robot {
                                 throw new ActionableError(`Swipe direction "${direction}" is not supported`);
                 }
 
-		this.adb("shell", "input", "swipe", `${x0}`, `${y0}`, `${x1}`, `${y1}`, "1000");
-	}
+                this.adb("shell", "input", "swipe", `${x0}`, `${y0}`, `${x1}`, `${y1}`, "1000");
+        }
+
+        public async swipeBetweenPoints(startX: number, startY: number, endX: number, endY: number): Promise<void> {
+                this.adb(
+                        "shell",
+                        "input",
+                        "swipe",
+                        `${startX}`,
+                        `${startY}`,
+                        `${endX}`,
+                        `${endY}`,
+                        "1000"
+                );
+        }
 
 	public async getScreenshot(): Promise<Buffer> {
 		return this.adb("exec-out", "screencap", "-p");

--- a/typescript_backup/src/ios.ts
+++ b/typescript_backup/src/ios.ts
@@ -116,10 +116,15 @@ export class IosRobot implements Robot {
 		return await wda.getScreenSize();
 	}
 
-	public async swipe(direction: SwipeDirection): Promise<void> {
-		const wda = await this.wda();
-		await wda.swipe(direction);
-	}
+        public async swipe(direction: SwipeDirection): Promise<void> {
+                const wda = await this.wda();
+                await wda.swipe(direction);
+        }
+
+        public async swipeBetweenPoints(startX: number, startY: number, endX: number, endY: number): Promise<void> {
+                const wda = await this.wda();
+                await wda.swipeBetweenPoints(startX, startY, endX, endY);
+        }
 
 	public async listApps(): Promise<InstalledApp[]> {
 		await this.assertTunnelRunning();

--- a/typescript_backup/src/iphone-simulator.ts
+++ b/typescript_backup/src/iphone-simulator.ts
@@ -168,10 +168,15 @@ export class Simctl implements Robot {
 		return wda.sendKeys(keys);
 	}
 
-	public async swipe(direction: SwipeDirection) {
-		const wda = await this.wda();
-		return wda.swipe(direction);
-	}
+        public async swipe(direction: SwipeDirection) {
+                const wda = await this.wda();
+                return wda.swipe(direction);
+        }
+
+        public async swipeBetweenPoints(startX: number, startY: number, endX: number, endY: number) {
+                const wda = await this.wda();
+                return wda.swipeBetweenPoints(startX, startY, endX, endY);
+        }
 
 	public async tap(x: number, y: number) {
 		const wda = await this.wda();

--- a/typescript_backup/src/robot.ts
+++ b/typescript_backup/src/robot.ts
@@ -50,10 +50,20 @@ export interface Robot {
 	 */
 	getScreenSize(): Promise<ScreenSize>;
 
-	/**
-	 * Swipe in a direction.
-	 */
-	swipe(direction: SwipeDirection): Promise<void>;
+        /**
+         * Swipe in a direction.
+         */
+        swipe(direction: SwipeDirection): Promise<void>;
+
+        /**
+         * Swipe from one coordinate to another.
+         */
+        swipeBetweenPoints(
+                startX: number,
+                startY: number,
+                endX: number,
+                endY: number
+        ): Promise<void>;
 
 	/**
 	 * Get a screenshot of the screen. Returns a Buffer that contains

--- a/typescript_backup/src/server.ts
+++ b/typescript_backup/src/server.ts
@@ -269,12 +269,21 @@ export const createMcpServer = (): McpServer => {
                 "swipe_on_screen",
                 "Swipe on the screen",
                 {
-                        direction: z.enum(["up", "down", "left", "right"]).describe("The direction to swipe"),
+                        direction: z.enum(["up", "down", "left", "right"]).describe("The direction to swipe").optional(),
+                        start_x: z.number().int().describe("Start X coordinate").optional(),
+                        start_y: z.number().int().describe("Start Y coordinate").optional(),
+                        end_x: z.number().int().describe("End X coordinate").optional(),
+                        end_y: z.number().int().describe("End Y coordinate").optional(),
                 },
-                async ({ direction }) => {
+                async ({ direction, start_x, start_y, end_x, end_y }) => {
                         requireRobot();
-                        await robot!.swipe(direction);
-                        return `Swiped ${direction} on screen`;
+                        if (direction) {
+                                await robot!.swipe(direction);
+                                return `Swiped ${direction} on screen`;
+                        } else {
+                                await robot!.swipeBetweenPoints(start_x!, start_y!, end_x!, end_y!);
+                                return `Swiped (${start_x},${start_y}) -> (${end_x},${end_y})`;
+                        }
                 }
         );
 

--- a/typescript_backup/src/webdriver-agent.ts
+++ b/typescript_backup/src/webdriver-agent.ts
@@ -267,8 +267,34 @@ export class WebDriverAgent {
 					]
 				}),
 			});
-		});
-	}
+                });
+        }
+
+        public async swipeBetweenPoints(startX: number, startY: number, endX: number, endY: number) {
+                await this.withinSession(async sessionUrl => {
+                        const url = `${sessionUrl}/actions`;
+                        await fetch(url, {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({
+                                        actions: [
+                                                {
+                                                        type: "pointer",
+                                                        id: "finger1",
+                                                        parameters: { pointerType: "touch" },
+                                                        actions: [
+                                                                { type: "pointerMove", duration: 0, x: startX, y: startY },
+                                                                { type: "pointerDown", button: 0 },
+                                                                { type: "pointerMove", duration: 0, x: endX, y: endY },
+                                                                { type: "pause", duration: 1000 },
+                                                                { type: "pointerUp", button: 0 }
+                                                        ]
+                                                }
+                                        ]
+                                })
+                        });
+                });
+        }
 
 	public async setOrientation(orientation: Orientation): Promise<void> {
 		await this.withinSession(async sessionUrl => {


### PR DESCRIPTION
## Summary
- allow swiping by specifying start and end coordinates
- support new gesture in Robot interface and platform implementations
- expose new functionality via `swipe_on_screen` tool
- update TypeScript backup sources
- extend swipe tests for new capability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68490763d17883249d3316812e2546d1