### PR TITLE
Fix screen element scaling

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -337,6 +337,8 @@ def create_mcp_server() -> Server:
 
             elif name == "mobile_list_elements_on_screen":
                 require_robot()
+                screen_size = await robot.get_screen_size()
+                scale = screen_size.scale if screen_size else 1
                 elements = await robot.get_elements_on_screen()
 
                 element_list = []


### PR DESCRIPTION
## Summary
- avoid undefined `scale` when listing screen elements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6849115bd9708324876dd897b60a4596