### PR TITLE
Fix iOS coordinate scaling

### DIFF
--- a/src/ios.py
+++ b/src/ios.py
@@ -151,7 +151,14 @@ class IosRobot(Robot):
     ) -> None:
         """지정된 좌표에서 다른 좌표까지 스와이프합니다."""
         wda = await self._wda()
-        await wda.swipe_between_points(start_x, start_y, end_x, end_y)
+        screen = await wda.get_screen_size()
+        scale = screen.scale if screen else 1
+        await wda.swipe_between_points(
+            int(start_x / scale),
+            int(start_y / scale),
+            int(end_x / scale),
+            int(end_y / scale),
+        )
     
     async def list_apps(self) -> List[InstalledApp]:
         """설치된 앱 목록을 가져옵니다."""
@@ -200,7 +207,9 @@ class IosRobot(Robot):
     async def tap(self, x: int, y: int) -> None:
         """지정된 좌표를 탭합니다."""
         wda = await self._wda()
-        await wda.tap(x, y)
+        screen = await wda.get_screen_size()
+        scale = screen.scale if screen else 1
+        await wda.tap(int(x / scale), int(y / scale))
     
     async def get_elements_on_screen(self) -> List[ScreenElement]:
         """화면의 모든 요소를 가져옵니다."""

--- a/tests/test_ios_coordinates.py
+++ b/tests/test_ios_coordinates.py
@@ -1,0 +1,30 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.ios import IosRobot
+from src.robot import ScreenSize
+
+
+class TestIosCoordinateScaling(unittest.TestCase):
+    def test_tap_scales_coordinates(self):
+        robot = IosRobot("serial")
+        mock_wda = MagicMock()
+        mock_wda.get_screen_size = AsyncMock(return_value=ScreenSize(width=100, height=200, scale=2))
+        mock_wda.tap = AsyncMock()
+        with patch.object(robot, "_wda", AsyncMock(return_value=mock_wda)):
+            asyncio.run(robot.tap(40, 60))
+            mock_wda.tap.assert_awaited_with(20, 30)
+
+    def test_swipe_between_points_scales_coordinates(self):
+        robot = IosRobot("serial")
+        mock_wda = MagicMock()
+        mock_wda.get_screen_size = AsyncMock(return_value=ScreenSize(width=100, height=200, scale=2))
+        mock_wda.swipe_between_points = AsyncMock()
+        with patch.object(robot, "_wda", AsyncMock(return_value=mock_wda)):
+            asyncio.run(robot.swipe_between_points(40, 60, 80, 120))
+            mock_wda.swipe_between_points.assert_awaited_with(20, 30, 40, 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scale down coordinates before passing to WebDriverAgent
- test coordinate scaling for iOS actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_684962cfcef883248846318b397e4110